### PR TITLE
Create region classes to abstract deployment further

### DIFF
--- a/inventory/classes/region/eu.yml
+++ b/inventory/classes/region/eu.yml
@@ -1,0 +1,2 @@
+parameters:
+  region: eu

--- a/inventory/classes/region/staging.yml
+++ b/inventory/classes/region/staging.yml
@@ -1,0 +1,6 @@
+parameters:
+  region: staging
+  application:
+    source:
+      targetRevision: staging
+

--- a/inventory/classes/region/us.yml
+++ b/inventory/classes/region/us.yml
@@ -1,0 +1,2 @@
+parameters:
+  region: us

--- a/inventory/targets/app1-deploy1.yml
+++ b/inventory/targets/app1-deploy1.yml
@@ -1,10 +1,7 @@
 classes:
   - common
   - application.app1
+  - region.staging
 
 parameters:
   target_name: app1-deploy1
-  region: staging
-  application:
-    source:
-      targetRevision: staging

--- a/inventory/targets/app1-deploy2.yml
+++ b/inventory/targets/app1-deploy2.yml
@@ -1,7 +1,7 @@
 classes:
   - common
   - application.app1
+  - region.us
 
 parameters:
   target_name: app1-deploy2
-  region: us

--- a/inventory/targets/app2-deploy1.yml
+++ b/inventory/targets/app2-deploy1.yml
@@ -1,7 +1,7 @@
 classes:
   - common
   - application.app2
+  - region.us
 
 parameters:
   target_name: app2-deploy1
-  region: us


### PR DESCRIPTION
This helps abstract deployments further and enable all characteristics of a deployment to be abstracted as classes. For example target only defines its name:

```
classes:
  - common
  - application.app1
  - region.staging

parameters:
  target_name: app1-deploy1
```